### PR TITLE
feature: add Git integration for cleanup files with automatic .gitignore handling

### DIFF
--- a/README.DEVELOP.md
+++ b/README.DEVELOP.md
@@ -1,0 +1,125 @@
+# Development Guide
+
+This guide covers everything you need to know for developing and contributing to bb-maid.
+
+## Table of Contents<!-- omit in toc -->
+
+- [Development Guide](#development-guide)
+  - [Local Development Setup](#local-development-setup)
+    - [Clone the Repository](#clone-the-repository)
+    - [Option A: Run tasks directly using babashka (quick testing)](#option-a-run-tasks-directly-using-babashka-quick-testing)
+    - [Option B: Install locally with bbin (test as end-users would experience it)](#option-b-install-locally-with-bbin-test-as-end-users-would-experience-it)
+    - [When to use each option](#when-to-use-each-option)
+  - [Project Structure](#project-structure)
+  - [Running Tests](#running-tests)
+  - [Adding Tests](#adding-tests)
+  - [Tab Completion Development](#tab-completion-development)
+
+## Local Development Setup
+
+### Clone the Repository
+
+```sh
+git clone https://github.com/simonneutert/bb-maid.git
+cd bb-maid
+```
+
+### Option A: Run tasks directly using babashka (quick testing)
+
+```sh
+bb tasks        # List available tasks
+bb clean .      # Clean current directory
+bb clean-in 7d  # Create cleanup file
+bb test         # Run tests
+```
+
+### Option B: Install locally with bbin (test as end-users would experience it)
+
+```sh
+# Install from project root
+bbin install .
+
+# Now test the actual bb-maid command
+bb-maid clean --help
+bb-maid clean-in 7d --gitignore
+
+# After making changes, reinstall to test updates
+bbin install . --force
+```
+
+### When to use each option
+
+- Use **Option A** (`bb` tasks) for quick iteration during development
+- Use **Option B** (`bbin install .`) to test the actual user experience, including:
+  - Command-line interface behavior
+  - Tab completion functionality
+  - Installation and upgrade workflows
+
+## Project Structure
+
+The project uses a proper Babashka structure with:
+- Source code in `src/simonneutert/bb_maid.clj`
+- Tasks defined in `bb.edn` that call functions directly
+- Tests in `test/simonneutert/bb_maid_test.clj`
+- Tab completion scripts in `completions/`
+
+## Running Tests
+
+bb-maid includes a test suite using `clojure.test`. To run the tests:
+
+```sh
+bb test
+```
+
+Or run the test runner directly:
+
+```sh
+bb test-runner.clj
+```
+
+The test suite covers:
+- Date parsing and validation
+- Duration string parsing (`7d`, `30d`, etc.)
+- Command-line option parsing
+- Option combinations and defaults
+- Symlink handling behavior (default: disabled, with --follow-links flag)
+- Git integration features
+- Gitignore file handling
+
+## Adding Tests
+
+Tests are located in `test/simonneutert/bb_maid_test.clj`. To add new tests:
+
+1. Add your test to the test namespace
+2. Run `bb test` to verify
+
+Example test:
+
+```clojure
+(deftest my-new-test
+  (testing "Description of what you're testing"
+    (is (= expected-value (function-call args)))))
+```
+
+## Tab Completion Development
+
+Tab completion scripts are located in the `completions/` directory:
+- `_bb-maid` - Zsh completion
+- `bb-maid.bash` - Bash completion
+
+When adding new commands or options, make sure to update both completion scripts.
+
+To test tab completion during development:
+
+**Zsh:**
+```sh
+# Temporarily load local completion
+fpath=(./completions $fpath)
+autoload -Uz compinit && compinit
+```
+
+**Bash:**
+```sh
+# Temporarily load local completion
+source ./completions/bb-maid.bash
+```

--- a/README.md
+++ b/README.md
@@ -40,9 +40,13 @@ This way, your system stays clean, just like your fridge stays free of expired l
   - [Setup for Bash](#setup-for-bash)
 - [How It Works](#how-it-works)
   - [Safety Features](#safety-features)
-- [Development](#development)
-  - [Running Tests](#running-tests)
-  - [Adding Tests](#adding-tests)
+- [Git Integration](#git-integration)
+  - [Quick Setup](#quick-setup)
+  - [Manual Git Configuration](#manual-git-configuration)
+    - [Project-specific exclusion (recommended)](#project-specific-exclusion-recommended)
+    - [Global Git configuration](#global-git-configuration)
+  - [Verifying Git Exclusion](#verifying-git-exclusion)
+- [Contributing](#contributing)
 - [License](#license)
 
 ## Prerequisites
@@ -81,26 +85,7 @@ bb-maid
 
 #### Local Development
 
-1. Clone the repository:
-
-```sh
-git clone https://github.com/simonneutert/bb-maid.git
-cd bb-maid
-```
-
-2. Run tasks directly using babashka:
-
-```sh
-bb tasks        # List available tasks
-bb clean .      # Clean current directory
-bb clean-in 7d  # Create cleanup file
-bb test         # Run tests
-```
-
-The project uses a proper Babashka structure with:
-- Source code in `src/simonneutert/bb_maid.clj`
-- Tasks defined in `bb.edn` that call functions directly
-- Tests in `test/simonneutert/bb_maid_test.clj`
+For development setup, testing, and contributing, see the [Development Guide](README.DEVELOP.md).
 
 ### Verify Installation
 
@@ -228,6 +213,12 @@ bb-maid clean-in 7d
 
 # Create cleanup file in specific directory (expires in 30 days)
 bb-maid clean-in 30d ~/temp-projects
+
+# Create cleanup file AND add to .gitignore in one command
+bb-maid clean-in 7d --gitignore
+
+# Create in specific directory with gitignore
+bb-maid clean-in 14d ~/projects/temp --gitignore
 ```
 
 ### Example
@@ -306,43 +297,80 @@ Then restart your terminal or run `source ~/.bashrc`.
 - **Non-destructive by default**: The script only suggests deletions; you have final control.
 - **Dry-run mode**: Test operations safely with `--dry-run` before actual deletion.
 
-## Development
+## Git Integration
 
-### Running Tests
+Since cleanup files are temporary markers that indicate when directories should be deleted, you typically don't want to commit them to your Git repository. bb-maid provides simple commands to automatically handle Git exclusion:
 
-bb-maid includes a test suite using `clojure.test`. To run the tests:
+### Quick Setup
 
-```sh
-bb test
-```
-
-Or run the test runner directly:
+The easiest way to exclude cleanup files from Git is to use the `--gitignore` option when creating cleanup files:
 
 ```sh
-bb test-runner.clj
+# Create cleanup file and add to .gitignore in one command
+bb-maid clean-in 7d --gitignore
 ```
 
-The test suite covers:
-- Date parsing and validation
-- Duration string parsing (`7d`, `30d`, etc.)
-- Command-line option parsing
-- Option combinations and defaults
-- Symlink handling behavior (default: disabled, with --follow-links flag)
+Or add the pattern to an existing project:
 
-### Adding Tests
-
-Tests are located in `test/simonneutert/bb_maid_test.clj`. To add new tests:
-
-1. Add your test to the test namespace
-2. Run `bb test` to verify
-
-Example test:
-
-```clojure
-(deftest my-new-test
-  (testing "Description of what you're testing"
-    (is (= expected-value (function-call args)))))
+```sh
+# Add cleanup-maid-* pattern to .gitignore
+bb-maid gitignore
 ```
+
+**💡 Smart Git Detection**: When you run `bb-maid clean-in` in a Git repository without the `--gitignore` flag, bb-maid will automatically show you a helpful tip suggesting the `--gitignore` option:
+
+```
+┏ INFO
+┃ 💡 Tip: You're in a Git repository! Use --gitignore to automatically add cleanup files to .gitignore:
+┃        bb-maid clean-in 7d --gitignore
+┗
+```
+
+### Manual Git Configuration
+
+If you prefer to set up Git exclusion manually, here are platform-specific instructions:
+
+#### Project-specific exclusion (recommended)
+
+```sh
+# Add to project's .gitignore
+echo "cleanup-maid-*" >> .gitignore
+git add .gitignore
+git commit -m "Ignore cleanup-maid files"
+```
+
+#### Global Git configuration
+
+**macOS/Linux:**
+```sh
+echo "cleanup-maid-*" >> ~/.gitignore_global
+git config --global core.excludesfile ~/.gitignore_global
+```
+
+**Windows (PowerShell):**
+```powershell
+"cleanup-maid-*" | Out-File -FilePath "$env:USERPROFILE\.gitignore_global" -Encoding UTF8 -Append
+git config --global core.excludesfile "$env:USERPROFILE\.gitignore_global"
+```
+
+### Verifying Git Exclusion
+
+To test if exclusion works:
+
+1. Create a test cleanup file: `touch cleanup-maid-2025-12-31`
+2. Check Git status: `git status`
+3. The file should **not** appear in untracked files
+4. Clean up: `rm cleanup-maid-2025-12-31`
+
+**Note:** If cleanup files are already tracked in Git, remove them first:
+```sh
+git rm --cached cleanup-maid-*
+git commit -m "Remove tracked cleanup-maid files"
+```
+
+## Contributing
+
+Contributions are welcome! For development setup, testing, and contribution guidelines, please see the [Development Guide](README.DEVELOP.md).
 
 ## License
 

--- a/bb.edn
+++ b/bb.edn
@@ -2,12 +2,15 @@
  :paths ["src"]
  :bbin/bin {bb-maid {:main-opts ["-m" "simonneutert.bb-maid"]}}
  :tasks {:requires ([simonneutert.bb-maid :as maid])
-         
+
          clean {:doc "Run cleanup script to remove expired directories"
                 :task (apply maid/-main "clean" *command-line-args*)}
-         
+
          clean-in {:doc "Create a cleanup file with expiration date (e.g., 'bb clean-in 7d')"
                    :task (apply maid/-main "clean-in" *command-line-args*)}
-         
+
+         gitignore {:doc "Add cleanup-maid-* pattern to .gitignore file"
+                    :task (apply maid/-main "gitignore" *command-line-args*)}
+
          test {:doc "Run tests"
                :task (shell "bb test-runner.clj")}}}

--- a/completions/_bb-maid
+++ b/completions/_bb-maid
@@ -5,6 +5,7 @@ _bb-maid() {
     commands=(
         'clean:Clean up expired directories'
         'clean-in:Create a cleanup file with expiration date'
+        'gitignore:Add cleanup-maid-* pattern to .gitignore'
     )
     durations=(
         '1d:1 day'
@@ -51,7 +52,14 @@ _bb-maid() {
                     esac
                     ;;
                 clean-in)
-                    _describe 'duration' durations
+                    # Mix of durations, directories and options
+                    _arguments \
+                        '1:duration:(1d 7d 14d 30d 60d 90d)' \
+                        '2:directory:_files -/' \
+                        '*::option:(--gitignore)'
+                    ;;
+                gitignore)
+                    _files -/
                     ;;
             esac
             ;;

--- a/completions/bb-maid.bash
+++ b/completions/bb-maid.bash
@@ -5,7 +5,7 @@ _bb-maid() {
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     # Subcommands
-    local subcommands="clean clean-in"
+    local subcommands="clean clean-in gitignore"
     
     # Clean command options
     local clean_opts="--max-depth --follow-links --yes -y --dry-run -n"
@@ -42,6 +42,21 @@ _bb-maid() {
                 COMPREPLY=( $(compgen -W "1d 7d 14d 30d 60d 90d" -- ${cur}) )
                 return 0
             fi
+            
+            # If current word starts with -, suggest clean-in options
+            if [[ ${cur} == -* ]] ; then
+                COMPREPLY=( $(compgen -W "--gitignore" -- ${cur}) )
+                return 0
+            fi
+            
+            # Otherwise suggest directories
+            COMPREPLY=( $(compgen -d -- ${cur}) )
+            return 0
+            ;;
+        gitignore)
+            # Suggest directories
+            COMPREPLY=( $(compgen -d -- ${cur}) )
+            return 0
             ;;
     esac
 }

--- a/test/simonneutert/bb_maid_test.clj
+++ b/test/simonneutert/bb_maid_test.clj
@@ -1,13 +1,17 @@
 (ns simonneutert.bb-maid-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
             [simonneutert.bb-maid :as maid]
             [babashka.fs :as fs]))
+
+;; Test constants to avoid duplication
+(def cleanup-file-regex #"cleanup-maid-\d{4}-\d{2}-\d{2}")
 
 (deftest extract-date-test
   (testing "Extracts date from valid cleanup-maid filename"
     (is (= "2025-10-15" (maid/extract-date "cleanup-maid-2025-10-15")))
     (is (= "2025-01-01" (maid/extract-date "cleanup-maid-2025-01-01"))))
-  
+
   (testing "Returns nil for invalid filenames"
     (is (nil? (maid/extract-date "not-a-cleanup-file")))
     (is (nil? (maid/extract-date "cleanup-maid-invalid")))
@@ -17,7 +21,7 @@
   (testing "Recognizes past dates"
     (is (true? (maid/past-date? "2020-01-01")))
     (is (true? (maid/past-date? "2024-01-01"))))
-  
+
   (testing "Recognizes future dates"
     (is (false? (maid/past-date? "2030-01-01")))
     (is (false? (maid/past-date? "2026-12-31")))))
@@ -27,7 +31,7 @@
     (is (= 7 (maid/parse-duration "7d")))
     (is (= 1 (maid/parse-duration "1d")))
     (is (= 90 (maid/parse-duration "90d"))))
-  
+
   (testing "Returns nil for invalid duration strings"
     (is (nil? (maid/parse-duration "7")))
     (is (nil? (maid/parse-duration "d7")))
@@ -43,41 +47,41 @@
   (testing "Parses directory path"
     (let [opts (maid/parse-clean-options ["/tmp/test"])]
       (is (= "/tmp/test" (:path opts)))))
-  
+
   (testing "Parses --max-depth flag"
     (let [opts (maid/parse-clean-options ["/tmp" "--max-depth" "5"])]
       (is (= "/tmp" (:path opts)))
       (is (= 5 (get-in opts [:glob-opts :max-depth])))))
-  
+
   (testing "Parses --follow-links flag"
     (let [opts (maid/parse-clean-options ["/tmp" "--follow-links"])]
       (is (true? (get-in opts [:glob-opts :follow-links])))))
-  
+
   (testing "Parses --yes/-y flag"
     (is (true? (:auto-confirm (maid/parse-clean-options ["/tmp" "--yes"]))))
     (is (true? (:auto-confirm (maid/parse-clean-options ["/tmp" "-y"])))))
-  
+
   (testing "Parses --dry-run/-n flag"
     (is (true? (:dry-run (maid/parse-clean-options ["/tmp" "--dry-run"]))))
     (is (true? (:dry-run (maid/parse-clean-options ["/tmp" "-n"])))))
-  
+
   (testing "Parses --list flag"
     (is (true? (:list (maid/parse-clean-options ["/tmp" "--list"]))))
     (is (false? (:list (maid/parse-clean-options ["/tmp"])))))
-  
+
   (testing "Combines multiple options"
     (let [opts (maid/parse-clean-options ["/tmp" "--max-depth" "3" "--dry-run" "-y"])]
       (is (= "/tmp" (:path opts)))
       (is (= 3 (get-in opts [:glob-opts :max-depth])))
       (is (true? (:dry-run opts)))
       (is (true? (:auto-confirm opts)))))
-  
+
   (testing "Combines --list with other options"
     (let [opts (maid/parse-clean-options ["/tmp" "--list" "--max-depth" "2"])]
       (is (= "/tmp" (:path opts)))
       (is (true? (:list opts)))
       (is (= 2 (get-in opts [:glob-opts :max-depth])))))
-  
+
   (testing "Default values"
     (let [opts (maid/parse-clean-options ["/tmp"])]
       (is (false? (get-in opts [:glob-opts :follow-links])))
@@ -92,7 +96,7 @@
     (is (nil? (maid/parse-duration "")))
     (is (nil? (maid/parse-duration "7")))
     (is (nil? (maid/parse-duration "d7"))))
-  
+
   (testing "parse-duration works with valid formats"
     (is (number? (maid/parse-duration "1d")))
     (is (= 365 (maid/parse-duration "365d")))))
@@ -102,19 +106,19 @@
     (let [opts (maid/parse-clean-options ["/tmp/test"])]
       (is (false? (get-in opts [:glob-opts :follow-links]))
           "By default, symlinks should NOT be followed for safety")))
-  
+
   (testing "Explicit --follow-links enables symlink traversal"
     (let [opts (maid/parse-clean-options ["/tmp/test" "--follow-links"])]
       (is (true? (get-in opts [:glob-opts :follow-links]))
           "When --follow-links is specified, symlinks should be followed")))
-  
+
   (testing "follow-links works with other options"
     (let [opts (maid/parse-clean-options ["/tmp" "--follow-links" "--max-depth" "3" "--dry-run"])]
       (is (true? (get-in opts [:glob-opts :follow-links])))
       (is (= 3 (get-in opts [:glob-opts :max-depth])))
       (is (true? (:dry-run opts)))
       (is (= "/tmp" (:path opts)))))
-  
+
   (testing "Order of options doesn't matter for follow-links"
     (let [opts1 (maid/parse-clean-options ["--follow-links" "/tmp"])
           opts2 (maid/parse-clean-options ["/tmp" "--follow-links"])]
@@ -128,13 +132,13 @@
     (let [opts (maid/parse-clean-options [])]
       (is (nil? (:path opts)))
       (is (false? (:dry-run opts)))))
-  
+
   (testing "Options work without a path"
     (let [opts (maid/parse-clean-options ["--dry-run" "--yes"])]
       (is (nil? (:path opts)))
       (is (true? (:dry-run opts)))
       (is (true? (:auto-confirm opts)))))
-  
+
   (testing "Options can come before implicit current directory"
     (let [opts (maid/parse-clean-options ["--max-depth" "2" "--dry-run"])]
       (is (nil? (:path opts)))
@@ -145,7 +149,7 @@
   (testing "create-cleanup-file accepts directory parameter"
     (is (fn? maid/create-cleanup-file)
         "Function should exist"))
-  
+
   (testing "remove-existing-cleanup-files accepts directory parameter"
     (is (fn? maid/remove-existing-cleanup-files)
         "Function should exist")))
@@ -154,23 +158,23 @@
   (testing "Handles relative paths"
     (let [opts (maid/parse-clean-options ["./subdir"])]
       (is (= "./subdir" (:path opts)))))
-  
+
   (testing "Handles absolute paths"
     (let [opts (maid/parse-clean-options ["/tmp/test"])]
       (is (= "/tmp/test" (:path opts)))))
-  
+
   (testing "Handles paths with spaces"
     (let [opts (maid/parse-clean-options ["/tmp/test folder"])]
       (is (= "/tmp/test folder" (:path opts)))))
-  
+
   (testing "Handles home directory paths"
     (let [opts (maid/parse-clean-options ["~/projects"])]
       (is (= "~/projects" (:path opts)))))
-  
+
   (testing "Handles current directory explicitly"
     (let [opts (maid/parse-clean-options ["."])]
       (is (= "." (:path opts)))))
-  
+
   (testing "Handles parent directory"
     (let [opts (maid/parse-clean-options [".."])]
       (is (= ".." (:path opts))))))
@@ -180,19 +184,19 @@
     (testing "clean with explicit path"
       (let [opts (maid/parse-clean-options ["/tmp"])]
         (is (= "/tmp" (:path opts)))))
-    
+
     (testing "clean with path and options"
       (let [opts (maid/parse-clean-options ["/tmp" "--dry-run" "--max-depth" "3"])]
         (is (= "/tmp" (:path opts)))
         (is (true? (:dry-run opts)))
         (is (= 3 (get-in opts [:glob-opts :max-depth])))))
-    
+
     (testing "clean with options before path"
       (let [opts (maid/parse-clean-options ["--dry-run" "/tmp" "--max-depth" "3"])]
         (is (= "/tmp" (:path opts)))
         (is (true? (:dry-run opts)))
         (is (= 3 (get-in opts [:glob-opts :max-depth])))))
-    
+
     (testing "Multiple paths uses last one (current behavior)"
       (let [opts (maid/parse-clean-options ["/tmp" "/other"])]
         (is (= "/other" (:path opts))
@@ -205,15 +209,15 @@
       (try
         (maid/create-cleanup-file duration temp-dir)
         (let [files (fs/list-dir temp-dir)
-              cleanup-files (filter #(re-matches #"cleanup-maid-\d{4}-\d{2}-\d{2}" 
-                                                  (fs/file-name %)) files)]
-          (is (= 1 (count cleanup-files)) 
+              cleanup-files (filter #(re-matches cleanup-file-regex
+                                                 (fs/file-name %)) files)]
+          (is (= 1 (count cleanup-files))
               "Should create exactly one cleanup file")
           (is (some? (first cleanup-files))
               "Cleanup file should exist"))
         (finally
           (fs/delete-tree temp-dir)))))
-  
+
   (testing "Creates cleanup file with correct future date"
     (let [temp-dir (str (fs/create-temp-dir))
           duration "14d"
@@ -221,8 +225,8 @@
       (try
         (maid/create-cleanup-file duration temp-dir)
         (let [files (fs/list-dir temp-dir)
-              cleanup-file (first (filter #(re-matches #"cleanup-maid-\d{4}-\d{2}-\d{2}" 
-                                                        (fs/file-name %)) files))
+              cleanup-file (first (filter #(re-matches cleanup-file-regex
+                                                       (fs/file-name %)) files))
               filename (fs/file-name cleanup-file)
               date-str (maid/extract-date filename)
               expected-date (maid/calculate-future-date days)
@@ -231,21 +235,21 @@
               "Cleanup file should have the correct future date"))
         (finally
           (fs/delete-tree temp-dir)))))
-  
+
   (testing "Removes existing cleanup files before creating new one"
     (let [temp-dir (str (fs/create-temp-dir))]
       (try
         ;; Create first cleanup file
         (maid/create-cleanup-file "7d" temp-dir)
         (let [first-files (fs/list-dir temp-dir)]
-          (is (= 1 (count first-files)) 
+          (is (= 1 (count first-files))
               "Should have one cleanup file after first creation"))
-        
+
         ;; Create second cleanup file - should replace the first
         (maid/create-cleanup-file "14d" temp-dir)
         (let [second-files (fs/list-dir temp-dir)
-              cleanup-files (filter #(re-matches #"cleanup-maid-\d{4}-\d{2}-\d{2}" 
-                                                  (fs/file-name %)) second-files)]
+              cleanup-files (filter #(re-matches cleanup-file-regex
+                                                 (fs/file-name %)) second-files)]
           (is (= 1 (count cleanup-files))
               "Should still have only one cleanup file after second creation")
           (is (some #(re-find #"cleanup-maid-" (str %)) cleanup-files)
@@ -259,13 +263,13 @@
           future-date (.plusDays today 7)
           date-str (.format future-date (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd"))]
       (is (= 7 (maid/days-until date-str)))))
-  
+
   (testing "Returns negative for past dates"
     (let [today (java.time.LocalDate/now)
           past-date (.minusDays today 5)
           date-str (.format past-date (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd"))]
       (is (= -5 (maid/days-until date-str)))))
-  
+
   (testing "Returns 0 for today"
     (let [today (java.time.LocalDate/now)
           date-str (.format today (java.time.format.DateTimeFormatter/ofPattern "yyyy-MM-dd"))]
@@ -278,13 +282,13 @@
           result (maid/format-date-display date-str)]
       (is (some? result)
           "Should return a non-nil result")))
-  
+
   (testing "Handles expired dates"
     (let [past-date "2025-09-01"
           result (maid/format-date-display past-date)]
       (is (some? result)
           "Should format expired dates")))
-  
+
   (testing "Handles upcoming dates"
     (let [future-date "2030-01-01"
           result (maid/format-date-display future-date)]
@@ -300,11 +304,11 @@
               dir2 (fs/create-dirs (fs/path temp-dir "upcoming"))]
           (spit (fs/file dir1 "cleanup-maid-2020-01-01") "")
           (spit (fs/file dir2 "cleanup-maid-2030-01-01") "")
-          
+
           ;; Test that list-cleanup-directories runs without error
           (let [opts {:glob-opts {:follow-links false
                                   :max-depth Integer/MAX_VALUE}}
-                result (with-out-str 
+                result (with-out-str
                          (maid/list-cleanup-directories temp-dir opts))]
             (is (some? result)
                 "Should produce output")
@@ -312,7 +316,7 @@
                 "Output should be a string")))
         (finally
           (fs/delete-tree temp-dir)))))
-  
+
   (testing "Handles empty directories"
     (let [temp-dir (str (fs/create-temp-dir))]
       (try
@@ -324,14 +328,14 @@
               "Should handle directories with no cleanup files"))
         (finally
           (fs/delete-tree temp-dir)))))
-  
+
   (testing "Respects max-depth option"
     (let [temp-dir (str (fs/create-temp-dir))]
       (try
         ;; Create nested structure
         (let [deep-dir (fs/create-dirs (fs/path temp-dir "level1" "level2" "level3"))]
           (spit (fs/file deep-dir "cleanup-maid-2025-01-01") "")
-          
+
           (let [opts-shallow {:glob-opts {:follow-links false
                                           :max-depth 1}}
                 opts-deep {:glob-opts {:follow-links false
@@ -350,12 +354,12 @@
         (let [expired-dir (fs/create-dirs (fs/path temp-dir "expired-dir"))]
           (spit (fs/file expired-dir "cleanup-maid-2020-01-01") "")
           (spit (fs/file expired-dir "important-file.txt") "Don't delete me!")
-          
+
           ;; Run list
           (let [opts {:glob-opts {:follow-links false
                                   :max-depth Integer/MAX_VALUE}}]
             (with-out-str (maid/list-cleanup-directories temp-dir opts)))
-          
+
           ;; Verify nothing was deleted
           (is (fs/exists? expired-dir)
               "Directory should still exist after listing")
@@ -363,6 +367,279 @@
               "Cleanup file should still exist")
           (is (fs/exists? (fs/file expired-dir "important-file.txt"))
               "Other files should not be affected"))
+        (finally
+          (fs/delete-tree temp-dir))))))
+
+(deftest gitignore-functionality-test
+  (testing "Creates new .gitignore file with cleanup-maid pattern"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        (with-out-str (maid/gitignore-cleanup-files temp-dir))
+        (let [gitignore-path (fs/path temp-dir ".gitignore")]
+          (is (fs/exists? gitignore-path)
+              ".gitignore file should be created")
+          (is (str/includes? (slurp (str gitignore-path)) "cleanup-maid-*")
+              ".gitignore should contain cleanup-maid-* pattern"))
+        (finally
+          (fs/delete-tree temp-dir)))))
+
+  (testing "Adds pattern to existing .gitignore file"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        ;; Create existing .gitignore with some content
+        (let [gitignore-path (fs/path temp-dir ".gitignore")]
+          (spit (str gitignore-path) "*.tmp\n*.log\n")
+
+          ;; Add cleanup-maid pattern
+          (with-out-str (maid/gitignore-cleanup-files temp-dir))
+
+          (let [content (slurp (str gitignore-path))]
+            (is (str/includes? content "*.tmp")
+                "Existing content should be preserved")
+            (is (str/includes? content "cleanup-maid-*")
+                "New pattern should be added")))
+        (finally
+          (fs/delete-tree temp-dir)))))
+
+  (testing "Does not duplicate pattern if already exists"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        ;; Create .gitignore with cleanup-maid pattern already present
+        (let [gitignore-path (fs/path temp-dir ".gitignore")]
+          (spit (str gitignore-path) "*.tmp\ncleanup-maid-*\n*.log\n")
+
+          ;; Try to add pattern again
+          (with-out-str (maid/gitignore-cleanup-files temp-dir))
+
+          (let [content (slurp (str gitignore-path))
+                pattern-count (count (re-seq #"cleanup-maid-\*" content))]
+            (is (= 1 pattern-count)
+                "Pattern should only appear once")))
+        (finally
+          (fs/delete-tree temp-dir)))))
+
+  (testing "Handles non-existent directory"
+    (let [non-existent-dir (str (fs/create-temp-dir))]
+      (fs/delete-tree non-existent-dir) ;; Ensure it doesn't exist
+      (is (some? (with-out-str (maid/gitignore-cleanup-files non-existent-dir)))
+          "Should handle non-existent directory gracefully")))
+
+  (testing "Handles file instead of directory"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        (let [temp-file (fs/file temp-dir "test-file")]
+          (spit temp-file "test content")
+          (is (some? (with-out-str (maid/gitignore-cleanup-files (str temp-file))))
+              "Should handle file path gracefully"))
+        (finally
+          (fs/delete-tree temp-dir))))))
+
+(deftest parse-clean-in-options-test
+  (testing "Parses duration only"
+    (let [opts (maid/parse-clean-in-options ["7d"])]
+      (is (= "7d" (:duration opts)))
+      (is (nil? (:path opts)))
+      (is (false? (:gitignore opts)))))
+
+  (testing "Parses duration and path"
+    (let [opts (maid/parse-clean-in-options ["14d" "/tmp/test"])]
+      (is (= "14d" (:duration opts)))
+      (is (= "/tmp/test" (:path opts)))
+      (is (false? (:gitignore opts)))))
+
+  (testing "Parses --gitignore flag"
+    (let [opts (maid/parse-clean-in-options ["7d" "--gitignore"])]
+      (is (= "7d" (:duration opts)))
+      (is (nil? (:path opts)))
+      (is (true? (:gitignore opts)))))
+
+  (testing "Parses all options together"
+    (let [opts (maid/parse-clean-in-options ["30d" "/home/user" "--gitignore"])]
+      (is (= "30d" (:duration opts)))
+      (is (= "/home/user" (:path opts)))
+      (is (true? (:gitignore opts)))))
+
+  (testing "Handles options in different order"
+    (let [opts1 (maid/parse-clean-in-options ["--gitignore" "7d" "/tmp"])
+          opts2 (maid/parse-clean-in-options ["7d" "--gitignore" "/tmp"])]
+      (is (= "7d" (:duration opts1)))
+      (is (= "/tmp" (:path opts1)))
+      (is (true? (:gitignore opts1)))
+      (is (= "7d" (:duration opts2)))
+      (is (= "/tmp" (:path opts2)))
+      (is (true? (:gitignore opts2)))))
+
+  (testing "Handles no arguments"
+    (let [opts (maid/parse-clean-in-options [])]
+      (is (nil? (:duration opts)))
+      (is (nil? (:path opts)))
+      (is (false? (:gitignore opts)))))
+
+  (testing "Warns about unknown options"
+    (let [result (with-out-str (maid/parse-clean-in-options ["7d" "--unknown-flag"]))]
+      (is (some? result)
+          "Should produce warning output for unknown flags"))))
+
+(deftest clean-in-with-gitignore-integration-test
+  (testing "Creates cleanup file and gitignore when --gitignore flag is used"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        ;; Simulate clean-in command with --gitignore
+        (let [opts (maid/parse-clean-in-options ["7d" temp-dir "--gitignore"])
+              duration (:duration opts)
+              path (:path opts)]
+          ;; Create cleanup file
+          (maid/create-cleanup-file duration path)
+          ;; Add to gitignore if flag is set
+          (when (:gitignore opts)
+            (maid/gitignore-cleanup-files path))
+
+          ;; Verify cleanup file was created
+          (let [files (fs/list-dir temp-dir)
+                cleanup-files (filter #(re-matches cleanup-file-regex
+                                                   (fs/file-name %)) files)]
+            (is (= 1 (count cleanup-files))
+                "Should create exactly one cleanup file"))
+
+          ;; Verify .gitignore was created and contains pattern
+          (let [gitignore-path (fs/path temp-dir ".gitignore")]
+            (is (fs/exists? gitignore-path)
+                ".gitignore should be created")
+            (is (str/includes? (slurp (str gitignore-path)) "cleanup-maid-*")
+                ".gitignore should contain cleanup-maid-* pattern")))
+        (finally
+          (fs/delete-tree temp-dir)))))
+
+  (testing "Creates cleanup file without gitignore when flag is not used"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        ;; Simulate clean-in command without --gitignore
+        (let [opts (maid/parse-clean-in-options ["7d" temp-dir])
+              duration (:duration opts)
+              path (:path opts)]
+          ;; Create cleanup file
+          (maid/create-cleanup-file duration path)
+          ;; Add to gitignore if flag is set (it shouldn't be)
+          (when (:gitignore opts)
+            (maid/gitignore-cleanup-files path))
+
+          ;; Verify cleanup file was created
+          (let [files (fs/list-dir temp-dir)
+                cleanup-files (filter #(re-matches cleanup-file-regex
+                                                   (fs/file-name %)) files)]
+            (is (= 1 (count cleanup-files))
+                "Should create exactly one cleanup file"))
+
+          ;; Verify .gitignore was NOT created
+          (let [gitignore-path (fs/path temp-dir ".gitignore")]
+            (is (not (fs/exists? gitignore-path))
+                ".gitignore should NOT be created when --gitignore flag is not used")))
+        (finally
+          (fs/delete-tree temp-dir))))))
+
+(deftest git-repository-detection-test
+  (testing "Detects Git repository"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        ;; Create .git directory to simulate Git repo
+        (fs/create-dirs (fs/path temp-dir ".git"))
+        (is (true? (maid/git-repository? temp-dir))
+            "Should detect Git repository when .git directory exists")
+        (finally
+          (fs/delete-tree temp-dir)))))
+
+  (testing "Does not detect non-Git directory"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        (is (false? (maid/git-repository? temp-dir))
+            "Should not detect Git repository when .git directory doesn't exist")
+        (finally
+          (fs/delete-tree temp-dir)))))
+
+  (testing "Git hint is shown when not using --gitignore in Git repo"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        ;; Create .git directory to simulate Git repo
+        (fs/create-dirs (fs/path temp-dir ".git"))
+        (let [output (with-out-str (maid/show-git-hint temp-dir))]
+          (is (str/includes? output "💡 Tip:")
+              "Should show Git tip when in Git repository")
+          (is (str/includes? output "--gitignore")
+              "Should mention --gitignore option in tip"))
+        (finally
+          (fs/delete-tree temp-dir)))))
+
+  (testing "No hint shown when not in Git repo"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        (let [output (with-out-str (maid/show-git-hint temp-dir))]
+          (is (= "" output)
+              "Should not show hint when not in Git repository"))
+        (finally
+          (fs/delete-tree temp-dir))))))
+
+(deftest clean-in-git-hint-integration-test
+  (testing "Shows Git hint when clean-in is used without --gitignore in Git repo"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        ;; Create .git directory to simulate Git repo
+        (fs/create-dirs (fs/path temp-dir ".git"))
+
+        ;; Simulate clean-in command without --gitignore
+        (let [opts (maid/parse-clean-in-options ["7d" temp-dir])
+              duration (:duration opts)
+              path (:path opts)
+              output (with-out-str
+                       (maid/create-cleanup-file duration path)
+                       (if (:gitignore opts)
+                         (maid/gitignore-cleanup-files path)
+                         (maid/show-git-hint path)))]
+
+          ;; Verify cleanup file was created
+          (let [files (fs/list-dir temp-dir)
+                cleanup-files (filter #(re-matches cleanup-file-regex
+                                                   (fs/file-name %)) files)]
+            (is (= 1 (count cleanup-files))
+                "Should create exactly one cleanup file"))
+
+          ;; Verify Git hint was shown
+          (is (str/includes? output "💡 Tip:")
+              "Should show Git tip in output")
+          (is (str/includes? output "--gitignore")
+              "Should mention --gitignore option"))
+        (finally
+          (fs/delete-tree temp-dir)))))
+
+  (testing "Does not show Git hint when --gitignore is used"
+    (let [temp-dir (str (fs/create-temp-dir))]
+      (try
+        ;; Create .git directory to simulate Git repo
+        (fs/create-dirs (fs/path temp-dir ".git"))
+
+        ;; Simulate clean-in command WITH --gitignore
+        (let [opts (maid/parse-clean-in-options ["7d" temp-dir "--gitignore"])
+              duration (:duration opts)
+              path (:path opts)
+              output (with-out-str
+                       (maid/create-cleanup-file duration path)
+                       (if (:gitignore opts)
+                         (maid/gitignore-cleanup-files path)
+                         (maid/show-git-hint path)))]
+
+          ;; Verify both cleanup file and .gitignore were created
+          (let [files (fs/list-dir temp-dir)
+                cleanup-files (filter #(re-matches cleanup-file-regex
+                                                   (fs/file-name %)) files)]
+            (is (= 1 (count cleanup-files))
+                "Should create exactly one cleanup file"))
+
+          (let [gitignore-path (fs/path temp-dir ".gitignore")]
+            (is (fs/exists? gitignore-path)
+                ".gitignore should be created"))
+
+          ;; Verify Git hint was NOT shown (since --gitignore was used)
+          (is (not (str/includes? output "💡 Tip:"))
+              "Should NOT show Git tip when --gitignore is used"))
         (finally
           (fs/delete-tree temp-dir))))))
 


### PR DESCRIPTION
This pull request introduces a new Git integration feature to `bb-maid`, allowing users to easily add cleanup file patterns to `.gitignore` and improving the development and contribution workflow. It adds a new `gitignore` command, updates documentation, enhances tab completion, and refactors `clean-in` to support a `--gitignore` flag. The most important changes are grouped below.

**Git Integration and Command Enhancements:**

* Added a new `gitignore` command to add the `cleanup-maid-*` pattern to `.gitignore`, with logic to avoid duplicates and handle missing files. Also added a `--gitignore` flag to `clean-in` for seamless integration. [[1]](diffhunk://#diff-86ed2b510bc597aaad15e7ae107ad2c3125fd2ed5910260537ac115648eabf49R54-L72) [[2]](diffhunk://#diff-86ed2b510bc597aaad15e7ae107ad2c3125fd2ed5910260537ac115648eabf49R156-R193) [[3]](diffhunk://#diff-86ed2b510bc597aaad15e7ae107ad2c3125fd2ed5910260537ac115648eabf49L233-R304) [[4]](diffhunk://#diff-86ed2b510bc597aaad15e7ae107ad2c3125fd2ed5910260537ac115648eabf49L243-R321) [[5]](diffhunk://#diff-86ed2b510bc597aaad15e7ae107ad2c3125fd2ed5910260537ac115648eabf49L257-R341) [[6]](diffhunk://#diff-62100e26b5ed7e930acb75d51f6f1eff9484b124a4fe8b260f77d33cfa78a55cR12-R14)
* When running `clean-in` inside a Git repository without `--gitignore`, the tool now displays a helpful tip suggesting the flag.

**Documentation Updates:**

* Added a comprehensive `README.DEVELOP.md` with local development, testing, and tab completion instructions.
* Updated `README.md` to document the new Git integration features, including usage examples, manual setup, and troubleshooting. The development and testing sections were moved to the new development guide. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R49) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R88) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R216-R221) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L309-R374)

**Tab Completion Improvements:**

* Updated both Zsh (`completions/_bb-maid`) and Bash (`completions/bb-maid.bash`) completion scripts to support the new `gitignore` command and the `--gitignore` flag for `clean-in`. [[1]](diffhunk://#diff-78556477a5d378446c54db3e97d385910e2135d902e8ea96d974ce42adfe7fc9R8) [[2]](diffhunk://#diff-78556477a5d378446c54db3e97d385910e2135d902e8ea96d974ce42adfe7fc9L54-R62) [[3]](diffhunk://#diff-75b14843815aaef62b1c232fcfe2daecb76db5044f1a6dfd1dc82cbbef7873daL8-R8) [[4]](diffhunk://#diff-75b14843815aaef62b1c232fcfe2daecb76db5044f1a6dfd1dc82cbbef7873daR45-R59)

**Testing Improvements:**

* Refactored tests to use a shared regex constant for cleanup file name matching, improving maintainability. [[1]](diffhunk://#diff-a16bc6636e5f913dc026490b2ff83f5d706c7f225d1c9d93ee01ba6c868307e6R3-R9) [[2]](diffhunk://#diff-a16bc6636e5f913dc026490b2ff83f5d706c7f225d1c9d93ee01ba6c868307e6L208-R212) [[3]](diffhunk://#diff-a16bc6636e5f913dc026490b2ff83f5d706c7f225d1c9d93ee01ba6c868307e6L224-R228)