### PR TITLE
feature: add Fish shell completion support and update documentation

### DIFF
--- a/README.DEVELOP.md
+++ b/README.DEVELOP.md
@@ -106,6 +106,7 @@ Example test:
 Tab completion scripts are located in the `completions/` directory:
 - `_bb-maid` - Zsh completion
 - `bb-maid.bash` - Bash completion
+- `bb-maid.fish` - Fish completion
 
 When adding new commands or options, make sure to update both completion scripts.
 
@@ -122,4 +123,10 @@ autoload -Uz compinit && compinit
 ```sh
 # Temporarily load local completion
 source ./completions/bb-maid.bash
+```
+
+**Fish:**
+```fish
+# Temporarily load local completion
+set -gx fish_complete_path ./completions $fish_complete_path
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This way, your system stays clean, just like your fridge stays free of expired l
   - [What Gets Completed](#what-gets-completed)
   - [Setup for Zsh](#setup-for-zsh)
   - [Setup for Bash](#setup-for-bash)
+  - [Setup for Fish](#setup-for-fish)
 - [How It Works](#how-it-works)
   - [Safety Features](#safety-features)
 - [Git Integration](#git-integration)
@@ -277,6 +278,23 @@ source /path/to/your/clone/bb-maid/completions/bb-maid.bash
 ```
 
 Then restart your terminal or run `source ~/.bashrc`.
+
+### Setup for Fish
+
+Add this to your Fish config (`~/.config/fish/config.fish`):
+
+```fish
+# bb-maid tab completion
+# If installed via bbin:
+set -gx fish_complete_path ~/.gitlibs/libs/io.github.simonneutert/bb-maid/*/completions $fish_complete_path
+```
+
+```fish
+# If cloned from git:
+set -gx fish_complete_path /path/to/your/clone/bb-maid/completions $fish_complete_path
+```
+
+Then restart your terminal or run `source ~/.config/fish/config.fish`.
 
 ## How It Works
 

--- a/completions/bb-maid.fish
+++ b/completions/bb-maid.fish
@@ -1,0 +1,33 @@
+# Fish completion for bb-maid
+
+# Disable file completion by default
+complete -c bb-maid -f
+
+# Main commands
+complete -c bb-maid -n "not __fish_seen_subcommand_from clean clean-in gitignore" -a "clean" -d "Clean up expired directories"
+complete -c bb-maid -n "not __fish_seen_subcommand_from clean clean-in gitignore" -a "clean-in" -d "Create a cleanup file with expiration date"
+complete -c bb-maid -n "not __fish_seen_subcommand_from clean clean-in gitignore" -a "gitignore" -d "Add cleanup-maid-* pattern to .gitignore"
+
+# Options for 'clean' command
+complete -c bb-maid -n "__fish_seen_subcommand_from clean" -l max-depth -d "Limit recursion depth" -r
+complete -c bb-maid -n "__fish_seen_subcommand_from clean" -l follow-links -d "Follow symbolic links"
+complete -c bb-maid -n "__fish_seen_subcommand_from clean" -l yes -s y -d "Skip confirmation prompts"
+complete -c bb-maid -n "__fish_seen_subcommand_from clean" -l dry-run -s n -d "Show what would be deleted"
+complete -c bb-maid -n "__fish_seen_subcommand_from clean" -a "(__fish_complete_directories)" -d "Directory to clean"
+
+# Duration suggestions for 'clean-in' command
+complete -c bb-maid -n "__fish_seen_subcommand_from clean-in; and not __fish_seen_argument -s g -l gitignore" -a "1d" -d "1 day"
+complete -c bb-maid -n "__fish_seen_subcommand_from clean-in; and not __fish_seen_argument -s g -l gitignore" -a "7d" -d "7 days"
+complete -c bb-maid -n "__fish_seen_subcommand_from clean-in; and not __fish_seen_argument -s g -l gitignore" -a "14d" -d "14 days"
+complete -c bb-maid -n "__fish_seen_subcommand_from clean-in; and not __fish_seen_argument -s g -l gitignore" -a "30d" -d "30 days"
+complete -c bb-maid -n "__fish_seen_subcommand_from clean-in; and not __fish_seen_argument -s g -l gitignore" -a "60d" -d "60 days"
+complete -c bb-maid -n "__fish_seen_subcommand_from clean-in; and not __fish_seen_argument -s g -l gitignore" -a "90d" -d "90 days"
+
+# Options for 'clean-in' command
+complete -c bb-maid -n "__fish_seen_subcommand_from clean-in" -l gitignore -d "Add to .gitignore"
+
+# Directory completion for 'clean-in' after duration
+complete -c bb-maid -n "__fish_seen_subcommand_from clean-in; and __fish_seen_argument -a '1d' '7d' '14d' '30d' '60d' '90d'" -a "(__fish_complete_directories)" -d "Directory"
+
+# Directory completion for 'gitignore' command
+complete -c bb-maid -n "__fish_seen_subcommand_from gitignore" -a "(__fish_complete_directories)" -d "Directory to add gitignore"

--- a/src/simonneutert/bb_maid.clj
+++ b/src/simonneutert/bb_maid.clj
@@ -1,8 +1,7 @@
 #!/usr/bin/env bb
 
 (ns simonneutert.bb-maid
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [babashka.fs :as fs]
             [bling.core :refer [bling callout]]))
 


### PR DESCRIPTION
This pull request adds support for the Fish shell to the `bb-maid` project by introducing a Fish completion script and updating the documentation to include setup instructions for Fish users. It also includes a minor cleanup in the source code's namespace requirements.

**Fish shell support:**

* Added a new Fish completion script `bb-maid.fish` in the `completions/` directory, providing command and option completions for `bb-maid`.
* Updated documentation in `README.md` and `README.DEVELOP.md` to include Fish setup instructions and reference the new completion script.

**Code cleanup:**

* Removed the unused `clojure.java.io` import from `src/simonneutert/bb_maid.clj`.